### PR TITLE
ZIO library standards

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scalaVer = "2.13.10"
+val scalaVer = "2.13.18"
 
 val attoVersion    = "0.7.2"
 val zioVersion     = "2.1.24"

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,11 @@
 val scalaVer = "2.13.10"
 
 val attoVersion    = "0.7.2"
-val zioVersion     = "2.0.12"
-val zioMockVersion = "1.0.0-RC11"
+val zioVersion     = "2.1.24"
+val zioMockVersion = "1.0.0-RC12"
 
 lazy val compileDependencies = Seq(
   "dev.zio"      %% "zio"        % zioVersion,
-  "dev.zio"      %% "zio-macros" % zioVersion,
   "org.tpolecat" %% "atto-core"  % attoVersion
 ) map (_ % Compile)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.12.0

--- a/src/main/scala/com/example/tictactoe/controller/Controller.scala
+++ b/src/main/scala/com/example/tictactoe/controller/Controller.scala
@@ -2,10 +2,16 @@ package com.example.tictactoe.controller
 
 import com.example.tictactoe.domain.State
 import zio._
-import zio.macros._
 
-@accessible
 trait Controller {
   def process(input: String, state: State): UIO[Option[State]]
   def render(state: State): UIO[String]
+}
+
+object Controller {
+  def process(input: String, state: State): ZIO[Controller, Nothing, Option[State]] =
+    ZIO.serviceWithZIO[Controller](_.process(input, state))
+
+  def render(state: State): ZIO[Controller, Nothing, String] =
+    ZIO.serviceWithZIO[Controller](_.render(state))
 }

--- a/src/main/scala/com/example/tictactoe/domain/Board.scala
+++ b/src/main/scala/com/example/tictactoe/domain/Board.scala
@@ -62,7 +62,7 @@ object Board {
 
     ZIO
       .foreach(horizontalWins ++ verticalWins ++ diagonalWins)(
-        ZIO.foreach(_)(value => ZIO.from(Field.make(value))).map(_.toSet)
+        ZIO.foreach(_)(value => ZIO.fromOption(Field.make(value))).map(_.toSet)
       )
       .map(_.toSet)
       .orDieWith(_ => new IllegalStateException)

--- a/src/main/scala/com/example/tictactoe/gameLogic/GameLogic.scala
+++ b/src/main/scala/com/example/tictactoe/gameLogic/GameLogic.scala
@@ -1,13 +1,22 @@
 package com.example.tictactoe.gameLogic
 
 import com.example.tictactoe.domain.Board.Field
-import com.example.tictactoe.domain.{AppError, GameResult, Piece}
+import com.example.tictactoe.domain.{ AppError, GameResult, Piece }
 import zio._
-import zio.macros._
 
-@accessible
 trait GameLogic {
   def putPiece(board: Map[Field, Piece], field: Field, piece: Piece): IO[AppError, Map[Field, Piece]]
   def gameResult(board: Map[Field, Piece]): UIO[GameResult]
   def nextTurn(currentTurn: Piece): UIO[Piece]
+}
+
+object GameLogic {
+  def putPiece(board: Map[Field, Piece], field: Field, piece: Piece): ZIO[GameLogic, AppError, Map[Field, Piece]] =
+    ZIO.serviceWithZIO[GameLogic](_.putPiece(board, field, piece))
+
+  def gameResult(board: Map[Field, Piece]): ZIO[GameLogic, Nothing, GameResult] =
+    ZIO.serviceWithZIO[GameLogic](_.gameResult(board))
+
+  def nextTurn(currentTurn: Piece): ZIO[GameLogic, Nothing, Piece] =
+    ZIO.serviceWithZIO[GameLogic](_.nextTurn(currentTurn))
 }

--- a/src/main/scala/com/example/tictactoe/mode/confirm/ConfirmMode.scala
+++ b/src/main/scala/com/example/tictactoe/mode/confirm/ConfirmMode.scala
@@ -2,10 +2,16 @@ package com.example.tictactoe.mode.confirm
 
 import com.example.tictactoe.domain.State
 import zio._
-import zio.macros._
 
-@accessible
 trait ConfirmMode {
   def process(input: String, state: State.Confirm): UIO[State]
   def render(state: State.Confirm): UIO[String]
+}
+
+object ConfirmMode {
+  def process(input: String, state: State.Confirm): ZIO[ConfirmMode, Nothing, State] =
+    ZIO.serviceWithZIO[ConfirmMode](_.process(input, state))
+
+  def render(state: State.Confirm): ZIO[ConfirmMode, Nothing, String] =
+    ZIO.serviceWithZIO[ConfirmMode](_.render(state))
 }

--- a/src/main/scala/com/example/tictactoe/mode/game/GameMode.scala
+++ b/src/main/scala/com/example/tictactoe/mode/game/GameMode.scala
@@ -2,10 +2,16 @@ package com.example.tictactoe.mode.game
 
 import com.example.tictactoe.domain.State
 import zio._
-import zio.macros._
 
-@accessible
 trait GameMode {
   def process(input: String, state: State.Game): UIO[State]
   def render(state: State.Game): UIO[String]
+}
+
+object GameMode {
+  def process(input: String, state: State.Game): ZIO[GameMode, Nothing, State] =
+    ZIO.serviceWithZIO[GameMode](_.process(input, state))
+
+  def render(state: State.Game): ZIO[GameMode, Nothing, String] =
+    ZIO.serviceWithZIO[GameMode](_.render(state))
 }

--- a/src/main/scala/com/example/tictactoe/mode/menu/MenuMode.scala
+++ b/src/main/scala/com/example/tictactoe/mode/menu/MenuMode.scala
@@ -2,10 +2,16 @@ package com.example.tictactoe.mode.menu
 
 import com.example.tictactoe.domain.State
 import zio._
-import zio.macros._
 
-@accessible
 trait MenuMode {
   def process(input: String, state: State.Menu): UIO[State]
   def render(state: State.Menu): UIO[String]
+}
+
+object MenuMode {
+  def process(input: String, state: State.Menu): ZIO[MenuMode, Nothing, State] =
+    ZIO.serviceWithZIO[MenuMode](_.process(input, state))
+
+  def render(state: State.Menu): ZIO[MenuMode, Nothing, String] =
+    ZIO.serviceWithZIO[MenuMode](_.render(state))
 }

--- a/src/main/scala/com/example/tictactoe/opponentAi/OpponentAi.scala
+++ b/src/main/scala/com/example/tictactoe/opponentAi/OpponentAi.scala
@@ -3,9 +3,12 @@ package com.example.tictactoe.opponentAi
 import com.example.tictactoe.domain.Board.Field
 import com.example.tictactoe.domain.Piece
 import zio._
-import zio.macros._
 
-@accessible
 trait OpponentAi {
   def randomMove(board: Map[Field, Piece]): UIO[Field]
+}
+
+object OpponentAi {
+  def randomMove(board: Map[Field, Piece]): ZIO[OpponentAi, Nothing, Field] =
+    ZIO.serviceWithZIO[OpponentAi](_.randomMove(board))
 }

--- a/src/main/scala/com/example/tictactoe/parser/confirm/ConfirmCommandParser.scala
+++ b/src/main/scala/com/example/tictactoe/parser/confirm/ConfirmCommandParser.scala
@@ -2,9 +2,12 @@ package com.example.tictactoe.parser.confirm
 
 import com.example.tictactoe.domain.{ AppError, ConfirmCommand }
 import zio._
-import zio.macros._
 
-@accessible
 trait ConfirmCommandParser {
   def parse(input: String): IO[AppError, ConfirmCommand]
+}
+
+object ConfirmCommandParser {
+  def parse(input: String): ZIO[ConfirmCommandParser, AppError, ConfirmCommand] =
+    ZIO.serviceWithZIO[ConfirmCommandParser](_.parse(input))
 }

--- a/src/main/scala/com/example/tictactoe/parser/game/GameCommandParser.scala
+++ b/src/main/scala/com/example/tictactoe/parser/game/GameCommandParser.scala
@@ -2,9 +2,12 @@ package com.example.tictactoe.parser.game
 
 import com.example.tictactoe.domain.{ AppError, GameCommand }
 import zio._
-import zio.macros._
 
-@accessible
 trait GameCommandParser {
   def parse(input: String): IO[AppError, GameCommand]
+}
+
+object GameCommandParser {
+  def parse(input: String): ZIO[GameCommandParser, AppError, GameCommand] =
+    ZIO.serviceWithZIO[GameCommandParser](_.parse(input))
 }

--- a/src/main/scala/com/example/tictactoe/parser/game/GameCommandParserLive.scala
+++ b/src/main/scala/com/example/tictactoe/parser/game/GameCommandParserLive.scala
@@ -8,7 +8,7 @@ import zio._
 
 final case class GameCommandParserLive() extends GameCommandParser {
   def parse(input: String): IO[AppError, GameCommand] =
-    ZIO.from(command.parse(input).done.option).orElseFail(ParseError)
+    ZIO.fromOption(command.parse(input).done.option).orElseFail(ParseError)
   private lazy val command: Parser[GameCommand] =
     choice(menu, put)
   private lazy val menu: Parser[GameCommand] =

--- a/src/main/scala/com/example/tictactoe/parser/menu/MenuCommandParser.scala
+++ b/src/main/scala/com/example/tictactoe/parser/menu/MenuCommandParser.scala
@@ -2,9 +2,12 @@ package com.example.tictactoe.parser.menu
 
 import com.example.tictactoe.domain.{ AppError, MenuCommand }
 import zio._
-import zio.macros._
 
-@accessible
 trait MenuCommandParser {
   def parse(input: String): IO[AppError, MenuCommand]
+}
+
+object MenuCommandParser {
+  def parse(input: String): ZIO[MenuCommandParser, AppError, MenuCommand] =
+    ZIO.serviceWithZIO[MenuCommandParser](_.parse(input))
 }

--- a/src/main/scala/com/example/tictactoe/runLoop/RunLoop.scala
+++ b/src/main/scala/com/example/tictactoe/runLoop/RunLoop.scala
@@ -3,9 +3,11 @@ package com.example.tictactoe.runLoop
 import com.example.tictactoe.domain.State
 import zio._
 
-import zio.macros._
-
-@accessible
 trait RunLoop {
   def step(state: State): UIO[Option[State]]
+}
+
+object RunLoop {
+  def step(state: State): ZIO[RunLoop, Nothing, Option[State]] =
+    ZIO.serviceWithZIO[RunLoop](_.step(state))
 }

--- a/src/main/scala/com/example/tictactoe/terminal/Terminal.scala
+++ b/src/main/scala/com/example/tictactoe/terminal/Terminal.scala
@@ -2,10 +2,15 @@ package com.example.tictactoe.terminal
 
 import zio._
 
-import zio.macros._
-
-@accessible
 trait Terminal {
   def getUserInput: UIO[String]
   def display(frame: String): UIO[Unit]
+}
+
+object Terminal {
+  def getUserInput: ZIO[Terminal, Nothing, String] =
+    ZIO.serviceWithZIO[Terminal](_.getUserInput)
+
+  def display(frame: String): ZIO[Terminal, Nothing, Unit] =
+    ZIO.serviceWithZIO[Terminal](_.display(frame))
 }

--- a/src/main/scala/com/example/tictactoe/view/confirm/ConfirmView.scala
+++ b/src/main/scala/com/example/tictactoe/view/confirm/ConfirmView.scala
@@ -2,11 +2,20 @@ package com.example.tictactoe.view.confirm
 
 import com.example.tictactoe.domain.{ ConfirmAction, ConfirmFooterMessage }
 import zio._
-import zio.macros._
 
-@accessible
 trait ConfirmView {
   def header(action: ConfirmAction): UIO[String]
   def content: UIO[String]
   def footer(message: ConfirmFooterMessage): UIO[String]
+}
+
+object ConfirmView {
+  def header(action: ConfirmAction): ZIO[ConfirmView, Nothing, String] =
+    ZIO.serviceWithZIO[ConfirmView](_.header(action))
+
+  def content: ZIO[ConfirmView, Nothing, String] =
+    ZIO.serviceWithZIO[ConfirmView](_.content)
+
+  def footer(message: ConfirmFooterMessage): ZIO[ConfirmView, Nothing, String] =
+    ZIO.serviceWithZIO[ConfirmView](_.footer(message))
 }

--- a/src/main/scala/com/example/tictactoe/view/game/GameView.scala
+++ b/src/main/scala/com/example/tictactoe/view/game/GameView.scala
@@ -3,11 +3,20 @@ package com.example.tictactoe.view.game
 import com.example.tictactoe.domain.Board.Field
 import com.example.tictactoe.domain.{ GameFooterMessage, GameResult, Piece, Player }
 import zio._
-import zio.macros._
 
-@accessible
 trait GameView {
   def header(result: GameResult, turn: Piece, player: Player): UIO[String]
   def content(board: Map[Field, Piece], result: GameResult): UIO[String]
   def footer(message: GameFooterMessage): UIO[String]
+}
+
+object GameView {
+  def header(result: GameResult, turn: Piece, player: Player): ZIO[GameView, Nothing, String] =
+    ZIO.serviceWithZIO[GameView](_.header(result, turn, player))
+
+  def content(board: Map[Field, Piece], result: GameResult): ZIO[GameView, Nothing, String] =
+    ZIO.serviceWithZIO[GameView](_.content(board, result))
+
+  def footer(message: GameFooterMessage): ZIO[GameView, Nothing, String] =
+    ZIO.serviceWithZIO[GameView](_.footer(message))
 }

--- a/src/main/scala/com/example/tictactoe/view/menu/MenuView.scala
+++ b/src/main/scala/com/example/tictactoe/view/menu/MenuView.scala
@@ -2,11 +2,20 @@ package com.example.tictactoe.view.menu
 
 import com.example.tictactoe.domain.MenuFooterMessage
 import zio._
-import zio.macros._
 
-@accessible
 trait MenuView {
   def header: UIO[String]
   def content(isSuspended: Boolean): UIO[String]
   def footer(message: MenuFooterMessage): UIO[String]
+}
+
+object MenuView {
+  def header: ZIO[MenuView, Nothing, String] =
+    ZIO.serviceWithZIO[MenuView](_.header)
+
+  def content(isSuspended: Boolean): ZIO[MenuView, Nothing, String] =
+    ZIO.serviceWithZIO[MenuView](_.content(isSuspended))
+
+  def footer(message: MenuFooterMessage): ZIO[MenuView, Nothing, String] =
+    ZIO.serviceWithZIO[MenuView](_.footer(message))
 }

--- a/src/test/scala/com/example/tictactoe/controller/ControllerSpec.scala
+++ b/src/test/scala/com/example/tictactoe/controller/ControllerSpec.scala
@@ -12,44 +12,44 @@ object ControllerSpec extends ZIOSpecDefault {
       suite("to process user input")(
         test("State.Confirm delegates to ConfirmMode") {
           for {
-            result <- Controller.process(userInput, confirmState).some.provideLayer(env)
+            result <- Controller.process(userInput, confirmState).some.provide(env)
           } yield assertTrue(result == menuState)
         },
         test("State.Game delegates to GameMode") {
           for {
-            result <- Controller.process(userInput, gameState).some.provideLayer(env)
+            result <- Controller.process(userInput, gameState).some.provide(env)
           } yield assertTrue(result == menuState)
         },
         test("State.Menu delegates to MenuMode") {
           for {
-            result <- Controller.process(userInput, menuState).some.provideLayer(env)
+            result <- Controller.process(userInput, menuState).some.provide(env)
           } yield assertTrue(result == confirmState)
         },
         test("State.Shutdown fails with Unit") {
           for {
-            result <- Controller.process(userInput, shutdownState).provideLayer(dummyEnv)
+            result <- Controller.process(userInput, shutdownState).provide(dummyEnv)
           } yield assertTrue(result.isEmpty)
         }
       ),
       suite("to render")(
         test("State.Confirm delegates to ConfirmMode") {
           for {
-            result <- Controller.render(confirmState).provideLayer(env)
+            result <- Controller.render(confirmState).provide(env)
           } yield assertTrue(result == renderedFrame)
         },
         test("State.Game delegates to GameMode") {
           for {
-            result <- Controller.render(gameState).provideLayer(env)
+            result <- Controller.render(gameState).provide(env)
           } yield assertTrue(result == renderedFrame)
         },
         test("State.Menu delegates to MenuMode") {
           for {
-            result <- Controller.render(menuState).provideLayer(env)
+            result <- Controller.render(menuState).provide(env)
           } yield assertTrue(result == renderedFrame)
         },
         test("State.Shutdown returns shutdown message") {
           for {
-            result <- Controller.render(shutdownState).provideLayer(dummyEnv)
+            result <- Controller.render(shutdownState).provide(dummyEnv)
           } yield assertTrue(result == shutdownMessage)
         }
       )

--- a/src/test/scala/com/example/tictactoe/gameLogic/GameLogicSpec.scala
+++ b/src/test/scala/com/example/tictactoe/gameLogic/GameLogicSpec.scala
@@ -78,7 +78,7 @@ object GameLogicSpec extends ZIOSpecDefault {
           } yield assertTrue(result == Piece.Cross)
         }
       )
-    ).provideLayer(GameLogicLive.layer)
+    ).provide(GameLogicLive.layer)
 
   private val board = Map[Field, Piece](
     Field.North -> Piece.Cross,

--- a/src/test/scala/com/example/tictactoe/parser/confim/ConfirmCommandParserSpec.scala
+++ b/src/test/scala/com/example/tictactoe/parser/confim/ConfirmCommandParserSpec.scala
@@ -26,7 +26,7 @@ object ConfirmCommandParserSpec extends ZIOSpecDefault {
           }
         }
       )
-    ).provideLayer(ConfirmCommandParserLive.layer)
+    ).provide(ConfirmCommandParserLive.layer)
 
   private val validCommands      = List("yes", "no")
   private val invalidCommandsGen = Gen.string.filter(!validCommands.contains(_))

--- a/src/test/scala/com/example/tictactoe/parser/game/GameCommandParserSpec.scala
+++ b/src/test/scala/com/example/tictactoe/parser/game/GameCommandParserSpec.scala
@@ -18,10 +18,10 @@ object GameCommandParserSpec extends ZIOSpecDefault {
           val results = ZIO.foreach(1 to 9) { n =>
             for {
               result        <- GameCommandParser.parse(s"$n").either.right
-              expectedField <- ZIO.from(Field.make(n))
+              expectedField <- ZIO.fromOption(Field.make(n))
             } yield assertTrue(result == GameCommand.Put(expectedField))
           }
-          results.flatMap(results => ZIO.from(results.reduceOption(_ && _)))
+          results.flatMap(results => ZIO.fromOption(results.reduceOption(_ && _)))
         },
         test("invalid command returns error") {
           check(invalidCommandsGen) { input =>
@@ -31,7 +31,7 @@ object GameCommandParserSpec extends ZIOSpecDefault {
           }
         }
       )
-    ).provideLayer(GameCommandParserLive.layer)
+    ).provide(GameCommandParserLive.layer)
 
   private val validCommands      = List(1 to 9)
   private val invalidCommandsGen = Gen.string.filter(!validCommands.contains(_))

--- a/src/test/scala/com/example/tictactoe/parser/menu/MenuCommandParserSpec.scala
+++ b/src/test/scala/com/example/tictactoe/parser/menu/MenuCommandParserSpec.scala
@@ -28,7 +28,7 @@ object MenuCommandParserSpec extends ZIOSpecDefault {
           } yield assertTrue(result == ParseError)
         }
       }
-    ).provideLayer(MenuCommandParserLive.layer)
+    ).provide(MenuCommandParserLive.layer)
   )
 
   private val validCommands      = List("new game", "resume", "quit")

--- a/src/test/scala/com/example/tictactoe/terminal/TerminalSpec.scala
+++ b/src/test/scala/com/example/tictactoe/terminal/TerminalSpec.scala
@@ -20,5 +20,5 @@ object TerminalSpec extends ZIOSpecDefault {
           } yield assertTrue(result == ())
         }
       }
-    ).provideLayer(TerminalLive.layer) @@ TestAspect.silent
+    ).provide(TerminalLive.layer) @@ TestAspect.silent
 }

--- a/src/test/scala/com/example/tictactoe/view/confirm/ConfirmViewSpec.scala
+++ b/src/test/scala/com/example/tictactoe/view/confirm/ConfirmViewSpec.scala
@@ -38,7 +38,7 @@ object ConfirmViewSpec extends ZIOSpecDefault {
           } yield assertTrue(result == invalidCommandMessage)
         }
       )
-    ).provideLayer(ConfirmViewLive.layer)
+    ).provide(ConfirmViewLive.layer)
 
   private val newGameDescription =
     """[New game]

--- a/src/test/scala/com/example/tictactoe/view/game/GameViewSpec.scala
+++ b/src/test/scala/com/example/tictactoe/view/game/GameViewSpec.scala
@@ -36,7 +36,7 @@ object GameViewSpec extends ZIOSpecDefault {
           } yield assertTrue(result == invalidCommandMessage)
         }
       )
-    ).provideLayer(GameViewLive.layer)
+    ).provide(GameViewLive.layer)
 
   private val emptyBoard = Map.empty[Field, Piece]
 

--- a/src/test/scala/com/example/tictactoe/view/menu/MenuViewSpec.scala
+++ b/src/test/scala/com/example/tictactoe/view/menu/MenuViewSpec.scala
@@ -38,7 +38,7 @@ object MenuViewSpec extends ZIOSpecDefault {
           } yield assertTrue(result == invalidCommandMessage)
         }
       )
-    ).provideLayer(MenuViewLive.layer)
+    ).provide(MenuViewLive.layer)
 
   private val asciiArtTicTacToe =
     """


### PR DESCRIPTION
Upgrade ZIO to 2.1.24 and refactor code to align with ZIO 2.x standards.

This involves removing the `zio-macros` dependency, replacing `@accessible` macros with explicit `ZIO.serviceWithZIO` calls, updating `Option` conversions to `ZIO.fromOption`, and using `provide` instead of `provideLayer` in tests, reflecting recommended patterns in ZIO 2.x.

---
<a href="https://cursor.com/background-agent?bcId=bc-f42e5ea7-7303-413a-be83-7ef40bad5d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f42e5ea7-7303-413a-be83-7ef40bad5d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core build tooling and ZIO versions, and replaces macro-generated accessors with handwritten ones; behavior should be equivalent but the dependency/toolchain bump can surface subtle runtime/test issues.
> 
> **Overview**
> **Modernizes the build and ZIO stack.** Bumps Scala to `2.13.18`, sbt to `1.12.0`, upgrades ZIO to `2.1.24` (and `zio-mock` RC12), and removes the `zio-macros` dependency.
> 
> **Replaces macro accessors with explicit ones.** Removes `@accessible` usage across services (`Controller`, `GameLogic`, modes, parsers, views, `Terminal`, `RunLoop`) and adds companion-object accessors implemented via `ZIO.serviceWithZIO`.
> 
> **Aligns with ZIO 2.x APIs.** Switches `ZIO.from` on `Option` to `ZIO.fromOption` in a few places (e.g., `Board.wins`, `GameCommandParserLive`, tests) and updates tests to use `.provide(...)` instead of `.provideLayer(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa52832024aca4bc093cd68cd6eec6fbaf9cada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->